### PR TITLE
로그인 페이지 및 기능 개발

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,13 +4,16 @@ import SignUp from "pages/SignUp"
 
 import React from "react"
 import { BrowserRouter, Route, Routes } from "react-router-dom"
+import { useTokenStore } from "store/store"
 
 function App() {
-  const isLogin = false
+  const tokenState = useTokenStore()
+
+  const isLoggedIn = () => !!tokenState.token
 
   return (
     <BrowserRouter>
-      {isLogin ? (
+      {isLoggedIn() ? (
         <Routes>
           <Route path="/" element={<Home />} />
         </Routes>

--- a/src/api/signInApi.ts
+++ b/src/api/signInApi.ts
@@ -1,0 +1,14 @@
+import axios from "axios"
+import env from "env"
+
+export interface SignInRequest {
+  email: string
+  password: string
+}
+
+export const signInApi = async (signInRequest: SignInRequest) => {
+  return axios.post(
+    `${env.REACT_APP_API_SERVER_URL}/api/sign-in`,
+    signInRequest,
+  )
+}

--- a/src/components/modal/LoginModal.tsx
+++ b/src/components/modal/LoginModal.tsx
@@ -1,0 +1,179 @@
+import React from "react"
+
+import Backdrop from "@mui/material/Backdrop"
+import Box from "@mui/material/Box"
+import Modal from "@mui/material/Modal"
+import Fade from "@mui/material/Fade"
+import Typography from "@mui/material/Typography"
+import { Button, Stack, TextField } from "@mui/material"
+import { signInApi, SignInRequest } from "api/signInApi"
+import { useAlert } from "hooks/useAlert"
+import { useTokenStore } from "store/store"
+
+const style = {
+  position: "absolute" as const,
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: 500,
+  bgcolor: "background.paper",
+  border: "2px solid #000",
+  boxShadow: 24,
+  p: 10,
+}
+
+interface LoginModalProps {
+  open: boolean
+  handleClose: () => void
+}
+
+const LoginModal = (props: LoginModalProps) => {
+  const { addSuccess, addError } = useAlert()
+  const { open, handleClose } = props
+  const tokenState = useTokenStore()
+  const [signInRequest, setSignInRequest] = React.useState<SignInRequest>({
+    email: "",
+    password: "",
+  })
+
+  const onEmailChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSignInRequest({
+      ...signInRequest,
+      email: e.target.value,
+    })
+  }
+
+  const onPasswordChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSignInRequest({
+      ...signInRequest,
+      password: e.target.value,
+    })
+  }
+
+  const checkRequest = (): boolean =>
+    !(!signInRequest.email || !signInRequest.password)
+
+  const onLoginButtonClick = () => {
+    if (!checkRequest()) {
+      addError("이메일, 비밀번호를 입력해주세요.")
+
+      return
+    }
+
+    signInApi(signInRequest)
+      .then(res => {
+        // TODO 토큰으로 변경되면 Bearer 제거
+        const authHeaderValue = res.headers.authorization
+
+        tokenState.setToken(authHeaderValue)
+        // TODO 로그인 성공하면 유저 정보 가져와야 한다.
+
+        addSuccess("로그인에 성공하였습니다.")
+        handleClose()
+      })
+      .catch(err => {
+        const { status } = err.response
+        if (status === 400) {
+          addError("이메일 또는 비밀번호가 정확하지 않습니다.")
+        }
+
+        if (status >= 500) {
+          addError("서버 오류입니다. 다시 시도해주세요.")
+        }
+      })
+  }
+
+  return (
+    <Modal
+      aria-labelledby="transition-modal-title"
+      aria-describedby="transition-modal-description"
+      open={open}
+      onClose={handleClose}
+      closeAfterTransition
+      slots={{ backdrop: Backdrop }}
+      slotProps={{
+        backdrop: {
+          timeout: 500,
+        },
+      }}
+    >
+      <Fade in={open}>
+        <Box sx={style}>
+          <Stack spacing={2}>
+            <Box>
+              <Typography
+                variant="h4"
+                component="h2"
+                sx={{
+                  textAlign: "center",
+                  marginBottom: 3,
+                }}
+              >
+                로그인
+              </Typography>
+            </Box>
+            <Stack spacing={2}>
+              <TextField
+                required
+                label="이메일"
+                variant="outlined"
+                value={signInRequest.email}
+                onChange={onEmailChanged}
+                helperText="usermail@email.com"
+              />
+              <TextField
+                required
+                type="password"
+                label="비밀번호"
+                variant="outlined"
+                value={signInRequest.password}
+                onChange={onPasswordChanged}
+                helperText="6자리 이상. 영문,숫자,특수기호 조합."
+              />
+            </Stack>
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "center",
+              }}
+            >
+              <Box
+                sx={{
+                  width: 300,
+                  marginTop: 1,
+                }}
+              >
+                <Stack
+                  direction="row"
+                  spacing={2}
+                  sx={{
+                    height: 50,
+                  }}
+                >
+                  <Button
+                    fullWidth
+                    size="large"
+                    variant="outlined"
+                    onClick={handleClose}
+                  >
+                    취소
+                  </Button>
+                  <Button
+                    fullWidth
+                    size="large"
+                    variant="contained"
+                    onClick={onLoginButtonClick}
+                  >
+                    로그인
+                  </Button>
+                </Stack>
+              </Box>
+            </Box>
+          </Stack>
+        </Box>
+      </Fade>
+    </Modal>
+  )
+}
+
+export default LoginModal

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,28 @@
 import React from "react"
+import { Button } from "@mui/material"
+import { useTokenStore } from "store/store"
+import { useAlert } from "hooks/useAlert"
 
 function Home() {
-  return <h1>Home</h1>
+  const tokenState = useTokenStore()
+  const { addInfo } = useAlert()
+
+  const onLogoutButtonClick = () => {
+    tokenState.clear()
+    addInfo("로그아웃 완료")
+  }
+
+  return (
+    <div>
+      <h1>Home</h1>
+      <Button
+        variant="contained"
+        onClick={onLogoutButtonClick}
+        color="secondary"
+      >
+        로그아웃
+      </Button>
+    </div>
+  )
 }
 export default Home

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,6 +1,26 @@
 import React from "react"
+import { Button } from "@mui/material"
+import LoginModal from "components/modal/LoginModal"
 
 function Landing() {
-  return <h1>landing</h1>
+  const [loginModalOpen, setLoginModalOpen] = React.useState<boolean>(false)
+
+  const openLoginModal = () => {
+    setLoginModalOpen(true)
+  }
+
+  const closeLoginModal = () => {
+    setLoginModalOpen(false)
+  }
+
+  return (
+    <div>
+      <h1>landing</h1>
+      <Button variant="contained" onClick={openLoginModal}>
+        로그인
+      </Button>
+      <LoginModal open={loginModalOpen} handleClose={closeLoginModal} />
+    </div>
+  )
 }
 export default Landing

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -77,8 +77,8 @@ const SignUp = () => {
     })
       .then(res => {
         if (res.status === 201) {
-          addSuccess("회원가입 성공!")
-          navigate("/login")
+          addSuccess("회원가입 성공! 로그인 버튼을 통해 로그인 해주세요.")
+          navigate("/")
         }
       })
       .catch(err => {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand"
+
+interface TokenStore {
+  token: string | null
+  clear: () => void
+  setToken: (token: string) => void
+}
+
+export const useTokenStore = create<TokenStore>(set => ({
+  token: null,
+  clear: () => set({ token: null }),
+  setToken: (token: string) => set(state => ({ token })),
+}))
+
+export default { useTokenStore }


### PR DESCRIPTION
- zustand 이용하여 상태관리 저장소 store 작성
  - token을 관리하는 store 작성
- 회원가입 성공시 이동 페이지 변경
  - 로그인 페이지로 이동에서 루트 페이지로 이동으로 변경
- 로그인 모달 및 로그인 기능 개발
  - 로그인 성공시 토큰 값 store에 저장
  - **현재는 token이 아니라 회원의 식별값임!**
- 로그인 여부에 따라 가능한 라우터를 변경하는 작업을 tokenStore를 이용하도록 변경