### PR TITLE
개발 기능 및 페이지 통합 작업

### DIFF
--- a/.github/workflows/dev-frontend-workflow.yml
+++ b/.github/workflows/dev-frontend-workflow.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm install
       # 프로젝트 빌드
       - name: Build
-        run: npm run build
+        run: npm run build:dev
       - name: S3-Deploy
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/package.json
+++ b/package.json
@@ -74,6 +74,5 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^3.0.3"
-  },
-  "proxy": "http://localhost:8080"
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Landing from "pages/Landing"
 import SignUp from "pages/SignUp"
 import { useTokenStore } from "store/tokenStore"
 import UserLayout from "Layouts/UserLayout"
+import AnonymousLayout from "Layouts/AnonymousLayout"
 
 function App() {
   const tokenState = useTokenStore()
@@ -24,8 +25,10 @@ function App() {
           </Routes>
         ) : (
           <Routes>
-            <Route path="/" element={<Landing />} />
-            <Route path="/sign-up" element={<SignUp />} />
+            <Route element={<AnonymousLayout />}>
+              <Route path="/" element={<Landing />} />
+              <Route path="/sign-up" element={<SignUp />} />
+            </Route>
           </Routes>
         )}
       </BrowserRouter>

--- a/src/Layouts/AnonymousLayout.tsx
+++ b/src/Layouts/AnonymousLayout.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+import { Outlet } from "react-router-dom"
+import "Layouts/Layout.css"
+import AnonymousHeader from "components/Header/AnonymousHeader"
+
+const AnonymousLayout = () => {
+  return (
+    <div className="default_layout">
+      <AnonymousHeader />
+      <main className="main">
+        <div className="anonymous_page">
+          <Outlet />
+        </div>
+      </main>
+    </div>
+  )
+}
+export default AnonymousLayout

--- a/src/Layouts/Layout.css
+++ b/src/Layouts/Layout.css
@@ -19,3 +19,8 @@
   height: 100%;
   background-color: rgba(0, 0, 0, 0.2);
 }
+.anonymous_page {
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.2);
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,54 @@
+import axios, { InternalAxiosRequestConfig } from "axios"
+import { API_SERVER_URL } from "env"
+import { useTokenStore } from "store/tokenStore"
+
+export const basicAxios = axios.create({
+  baseURL: `${API_SERVER_URL}`,
+  headers: {
+    "Content-type": "application/json",
+  },
+})
+
+export const authAxios = axios.create({
+  baseURL: `${API_SERVER_URL}`,
+  headers: {
+    "Content-type": "application/json",
+  },
+})
+
+// 요청 인터셉터: 인증 헤더 자동 설정
+authAxios.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    const { headers } = config
+    const { token } = useTokenStore()
+
+    if (token) {
+      // TODO Bearer Token
+      headers.Authorization = `${token}`
+      // TODO 토큰 없을 경우 재발급 진행
+    }
+
+    return config
+  },
+  err => {
+    console.error(err)
+
+    return Promise.reject(err)
+  },
+)
+
+// 응답 인터셉터: 응답에 따른 callback 처리
+authAxios.interceptors.response.use(
+  response => {
+    return response
+  },
+  err => {
+    console.error(err)
+    // TODO 401: 인증되지 않은 사용자 -> 토큰 재발급 시도
+    if (err.response.status === 401) {
+      console.log("재발급 시도...")
+    }
+  },
+)
+
+export default { basicAxios, authAxios }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -44,9 +44,8 @@ authAxios.interceptors.response.use(
   },
   err => {
     console.error(err)
-    // TODO 401: 인증되지 않은 사용자 -> 토큰 재발급 시도
     if (err.response.status === 401) {
-      console.log("재발급 시도...")
+      // TODO 401: 인증되지 않은 사용자 -> 토큰 재발급 시도
     }
   },
 )

--- a/src/api/signInApi.ts
+++ b/src/api/signInApi.ts
@@ -1,5 +1,4 @@
-import axios from "axios"
-import { API_SERVER_URL } from "env"
+import { basicAxios } from "api/index"
 
 export interface SignInRequest {
   email: string
@@ -7,5 +6,5 @@ export interface SignInRequest {
 }
 
 export const signInApi = async (signInRequest: SignInRequest) => {
-  return axios.post(`${API_SERVER_URL}/api/sign-in`, signInRequest)
+  return basicAxios.post("/api/sign-in", signInRequest)
 }

--- a/src/api/signUpApi.ts
+++ b/src/api/signUpApi.ts
@@ -1,5 +1,4 @@
-import axios from "axios"
-import { API_SERVER_URL } from "env"
+import { basicAxios } from "api/index"
 
 export interface SignUpRequest {
   email: string
@@ -8,5 +7,5 @@ export interface SignUpRequest {
 }
 
 export const signUpApi = async (signUpRequest: SignUpRequest) => {
-  return axios.post(`${API_SERVER_URL}/api/sign-up`, signUpRequest)
+  return basicAxios.post("/api/sign-up", signUpRequest)
 }

--- a/src/api/workspaceApi.ts
+++ b/src/api/workspaceApi.ts
@@ -1,10 +1,9 @@
-import axios from "axios"
-import { API_SERVER_URL } from "env"
+import { authAxios } from "api/index"
 
 export interface WorkspaceInfo {
   name: string
   imageUrl: string | null
-  description: string | null
+  description: string
   subject: string
 }
 
@@ -23,6 +22,5 @@ export interface CreateWorkspaceResponse {
 }
 
 export const createWorkspaceApi = async (request: CreateWorkspaceRequest) => {
-  // TODO 토큰 헤더에 담기
-  return axios.post(`${API_SERVER_URL}/api/workspaces`, request)
+  return authAxios.post("/api/workspaces", request)
 }

--- a/src/components/Header/AnonymousHeader.tsx
+++ b/src/components/Header/AnonymousHeader.tsx
@@ -5,6 +5,7 @@ import Typography from "@mui/material/Typography"
 import { Box, Button } from "@mui/material"
 import LoginModal from "components/modal/LoginModal"
 import { Link } from "react-router-dom"
+import Stack from "@mui/material/Stack"
 
 const AnonymousHeader = () => {
   const [loginModalOpen, setLoginModalOpen] = React.useState<boolean>(false)
@@ -36,9 +37,17 @@ const AnonymousHeader = () => {
           </Link>
         </Typography>
         <Box>
-          <Button color="inherit" onClick={openLoginModal}>
-            로그인
-          </Button>
+          <Stack spacing={2} direction="row">
+            <Link
+              to="/sign-up"
+              style={{ textDecoration: "none", color: "inherit" }}
+            >
+              <Button color="inherit">회원가입</Button>
+            </Link>
+            <Button color="inherit" onClick={openLoginModal}>
+              로그인
+            </Button>
+          </Stack>
           <LoginModal open={loginModalOpen} handleClose={closeLoginModal} />
         </Box>
       </Toolbar>

--- a/src/components/Header/AnonymousHeader.tsx
+++ b/src/components/Header/AnonymousHeader.tsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+import AppBar from "@mui/material/AppBar"
+import Toolbar from "@mui/material/Toolbar"
+import Typography from "@mui/material/Typography"
+import { Box, Button } from "@mui/material"
+import LoginModal from "components/modal/LoginModal"
+import { Link } from "react-router-dom"
+
+const AnonymousHeader = () => {
+  const [loginModalOpen, setLoginModalOpen] = React.useState<boolean>(false)
+
+  const openLoginModal = () => setLoginModalOpen(true)
+
+  const closeLoginModal = () => setLoginModalOpen(false)
+
+  return (
+    <AppBar position="static">
+      <Toolbar>
+        {/* Nav */}
+        <Typography
+          variant="h6"
+          noWrap
+          component="div"
+          sx={{
+            mr: 2,
+            fontFamily: "monospace",
+            fontWeight: 700,
+            letterSpacing: ".3rem",
+            color: "inherit",
+            textDecoration: "none",
+          }}
+          flexGrow={1}
+        >
+          <Link to="/" style={{ textDecoration: "none", color: "inherit" }}>
+            LOGO
+          </Link>
+        </Typography>
+        <Box>
+          <Button color="inherit" onClick={openLoginModal}>
+            로그인
+          </Button>
+          <LoginModal open={loginModalOpen} handleClose={closeLoginModal} />
+        </Box>
+      </Toolbar>
+    </AppBar>
+  )
+}
+
+export default AnonymousHeader

--- a/src/components/Header/Nav.tsx
+++ b/src/components/Header/Nav.tsx
@@ -5,10 +5,15 @@ import Menu from "@mui/material/Menu"
 import Button from "@mui/material/Button"
 import Tooltip from "@mui/material/Tooltip"
 import MenuItem from "@mui/material/MenuItem"
+import { Link } from "react-router-dom"
+import CreateWorkspaceModal from "components/modal/CreateWorkspaceModal"
 
 const myWorkspaces = ["워크스페이스1", "워크스페이스2"]
+
 const Nav = () => {
   const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(null)
+  const [createWorkspaceModalOpen, setCreateWorkspaceModalOpen] =
+    React.useState<boolean>(false)
 
   const handleOpenNavMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorElNav(event.currentTarget)
@@ -18,13 +23,19 @@ const Nav = () => {
     setAnchorElNav(null)
   }
 
+  const openCreateWorkspaceModal = () => {
+    handleCloseNavMenu()
+    setCreateWorkspaceModalOpen(true)
+  }
+
+  const closeCreateWorkspaceModal = () => setCreateWorkspaceModalOpen(false)
+
   return (
     <>
       <Typography
         variant="h6"
         noWrap
-        component="a"
-        href="#app-bar-with-responsive-menu"
+        component="div"
         sx={{
           mr: 2,
           fontFamily: "monospace",
@@ -34,7 +45,9 @@ const Nav = () => {
           textDecoration: "none",
         }}
       >
-        LOGO
+        <Link to="/" style={{ textDecoration: "none", color: "inherit" }}>
+          LOGO
+        </Link>
       </Typography>
 
       {/* 워크스페이스 */}
@@ -69,11 +82,15 @@ const Nav = () => {
             </MenuItem>
           ))}
           <hr />
-          <MenuItem onClick={handleCloseNavMenu}>
+          <MenuItem onClick={openCreateWorkspaceModal}>
             <Typography textAlign="center">워크스페이스 생성</Typography>
           </MenuItem>
         </Menu>
       </Box>
+      <CreateWorkspaceModal
+        open={createWorkspaceModalOpen}
+        handleClose={closeCreateWorkspaceModal}
+      />
     </>
   )
 }

--- a/src/components/Header/UserInfo.tsx
+++ b/src/components/Header/UserInfo.tsx
@@ -6,10 +6,12 @@ import Typography from "@mui/material/Typography"
 import Menu from "@mui/material/Menu"
 import Tooltip from "@mui/material/Tooltip"
 import MenuItem from "@mui/material/MenuItem"
-
-const settings = ["Profile", "Logout"]
+import { useTokenStore } from "store/tokenStore"
+import { useAlert } from "hooks/useAlert"
 
 const UserInfo = () => {
+  const tokenState = useTokenStore()
+  const { addInfo } = useAlert()
   const [anchorElUser, setAnchorElUser] = React.useState<null | HTMLElement>(
     null,
   )
@@ -21,6 +23,19 @@ const UserInfo = () => {
   const handleCloseUserMenu = () => {
     setAnchorElUser(null)
   }
+
+  const onLogoutButtonClick = () => {
+    tokenState.clear()
+    addInfo("로그아웃 완료")
+    // menu 닫기
+    handleCloseUserMenu()
+  }
+
+  // 각 메뉴 클릭에 해당하는 callback 함수 지정
+  const settings = [
+    { name: "Profile", onClick: handleCloseUserMenu },
+    { name: "Logout", onClick: onLogoutButtonClick },
+  ]
 
   return (
     <Box sx={{ flexGrow: 0 }}>
@@ -46,8 +61,8 @@ const UserInfo = () => {
         onClose={handleCloseUserMenu}
       >
         {settings.map(setting => (
-          <MenuItem key={setting} onClick={handleCloseUserMenu}>
-            <Typography textAlign="center">{setting}</Typography>
+          <MenuItem key={setting.name} onClick={setting.onClick}>
+            <Typography textAlign="center">{setting.name}</Typography>
           </MenuItem>
         ))}
       </Menu>

--- a/src/components/modal/CreateWorkspaceModal.tsx
+++ b/src/components/modal/CreateWorkspaceModal.tsx
@@ -7,11 +7,8 @@ import Button from "@mui/material/Button"
 import InputWsProfileInfo from "components/modal/InputWsProfileInfo"
 import InputWorkspaceInfo from "components/modal/InputWorkspaceInfo"
 import { AxiosResponse } from "axios"
-import {
-  createWorkspaceApi,
-  CreateWorkspaceResponse,
-} from "../../api/workspaceApi"
-import { useCreateWorkspaceStore } from "../../store/requestStore"
+import { useCreateWorkspaceStore } from "store/requestStore"
+import { createWorkspaceApi, CreateWorkspaceResponse } from "api/workspaceApi"
 
 interface RenderInputWorkspaceInfoProps {
   onCancelBtnClick: () => void

--- a/src/components/modal/CreateWorkspaceModal.tsx
+++ b/src/components/modal/CreateWorkspaceModal.tsx
@@ -124,7 +124,6 @@ const CreateWorkspaceModal = (props: CreateWorkspaceModalProps) => {
     createWorkspaceApi(createWorkspaceState.createWorkspaceRequest)
       .then((res: AxiosResponse<CreateWorkspaceResponse>) => {
         if (res.status === 201) {
-          console.log(res.data)
           addSuccess("워크스페이스가 생성되었습니다.")
           // TODO 페이지 이동 필요
         }

--- a/src/components/modal/LoginModal.tsx
+++ b/src/components/modal/LoginModal.tsx
@@ -9,6 +9,7 @@ import { Button, Stack, TextField } from "@mui/material"
 import { signInApi, SignInRequest } from "api/signInApi"
 import { useAlert } from "hooks/useAlert"
 import { useTokenStore } from "store/tokenStore"
+import { useNavigate } from "react-router-dom"
 
 const style = {
   position: "absolute" as const,
@@ -28,6 +29,7 @@ interface LoginModalProps {
 }
 
 const LoginModal = (props: LoginModalProps) => {
+  const navigate = useNavigate()
   const { addSuccess, addError } = useAlert()
   const { open, handleClose } = props
   const tokenState = useTokenStore()
@@ -69,6 +71,7 @@ const LoginModal = (props: LoginModalProps) => {
         // TODO 로그인 성공하면 유저 정보 가져와야 한다.
 
         addSuccess("로그인에 성공하였습니다.")
+        navigate("/")
         handleClose()
       })
       .catch(err => {
@@ -83,10 +86,24 @@ const LoginModal = (props: LoginModalProps) => {
       })
   }
 
+  const onEnterKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      onLoginButtonClick()
+    }
+  }
+
+  /**
+   * 모달 닫을 때 clean-up 함수
+   */
+  const cleanUp = () => {
+    setSignInRequest({
+      email: "",
+      password: "",
+    })
+  }
+
   return (
     <Modal
-      aria-labelledby="transition-modal-title"
-      aria-describedby="transition-modal-description"
       open={open}
       onClose={handleClose}
       closeAfterTransition
@@ -96,6 +113,7 @@ const LoginModal = (props: LoginModalProps) => {
           timeout: 500,
         },
       }}
+      onTransitionExited={cleanUp}
     >
       <Fade in={open}>
         <Box sx={style}>
@@ -120,6 +138,7 @@ const LoginModal = (props: LoginModalProps) => {
                 value={signInRequest.email}
                 onChange={onEmailChanged}
                 helperText="usermail@email.com"
+                onKeyDown={onEnterKeyDown}
               />
               <TextField
                 required
@@ -129,6 +148,7 @@ const LoginModal = (props: LoginModalProps) => {
                 value={signInRequest.password}
                 onChange={onPasswordChanged}
                 helperText="6자리 이상. 영문,숫자,특수기호 조합."
+                onKeyDown={onEnterKeyDown}
               />
             </Stack>
             <Box

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,27 +1,9 @@
 import React from "react"
-import { Button } from "@mui/material"
-import { useTokenStore } from "store/tokenStore"
-import { useAlert } from "hooks/useAlert"
 
 const Home = () => {
-  const tokenState = useTokenStore()
-  const { addInfo } = useAlert()
-
-  const onLogoutButtonClick = () => {
-    tokenState.clear()
-    addInfo("로그아웃 완료")
-  }
-
   return (
     <div>
       <h1>Home</h1>
-      <Button
-        variant="contained"
-        onClick={onLogoutButtonClick}
-        color="secondary"
-      >
-        로그아웃
-      </Button>
     </div>
   )
 }

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,25 +1,9 @@
 import React from "react"
-import { Button } from "@mui/material"
-import LoginModal from "components/modal/LoginModal"
 
 function Landing() {
-  const [loginModalOpen, setLoginModalOpen] = React.useState<boolean>(false)
-
-  const openLoginModal = () => {
-    setLoginModalOpen(true)
-  }
-
-  const closeLoginModal = () => {
-    setLoginModalOpen(false)
-  }
-
   return (
     <div>
       <h1>landing</h1>
-      <Button variant="contained" onClick={openLoginModal}>
-        로그인
-      </Button>
-      <LoginModal open={loginModalOpen} handleClose={closeLoginModal} />
     </div>
   )
 }

--- a/src/store/requestStore.ts
+++ b/src/store/requestStore.ts
@@ -14,7 +14,7 @@ export const useCreateWorkspaceStore = create<CreateWorkspaceStore>(set => ({
     workspace: {
       name: "",
       imageUrl: null,
-      description: null,
+      description: "",
       subject: "",
     },
     profile: {
@@ -28,7 +28,7 @@ export const useCreateWorkspaceStore = create<CreateWorkspaceStore>(set => ({
         workspace: {
           name: "",
           imageUrl: null,
-          description: null,
+          description: "",
           subject: "",
         },
         profile: {
@@ -41,4 +41,4 @@ export const useCreateWorkspaceStore = create<CreateWorkspaceStore>(set => ({
     set(() => ({ createWorkspaceRequest })),
 }))
 
-export default { useTokenStore: useCreateWorkspaceStore }
+export default { useCreateWorkspaceStore }


### PR DESCRIPTION
- root path header 추가
  - 회원가입 버튼 추가
  - 로그인 버튼 추가
- 인증 된 사용자의 경우
  - 워크스페이스 생성 버튼 -> 워크스페이스 생성 모달 오픈
  - 계정 아이콘 -> 로그아웃 버튼 -> 로그아웃 실행
  - **로그아웃의 경우, API 개발되면 연동 필요. 로그아웃 확인을 묻는 창 필요**
- axios 설정 : **src/api/index.ts**
  - base path 설정
  - basicAxios : 인증 헤더를 담지 않는 axios
  - authAxios: 인증 헤더를 담아주는 axios. **추후 토큰이 없거나 401 응답시 재발급하는 로직 작성 필요**