### PR TITLE
[Home페이지] 워크스페이스 리스트 

### DIFF
--- a/src/components/workspace/list/TitleWrapper.tsx
+++ b/src/components/workspace/list/TitleWrapper.tsx
@@ -1,0 +1,50 @@
+import React, { ReactNode } from "react"
+import { Box, Typography } from "@mui/material"
+
+interface TitleWrapperProps {
+  children: ReactNode
+  title: string
+}
+const TitleWrapper: React.FC<TitleWrapperProps> = ({ children, title }) => {
+  return (
+    <Box
+      sx={{
+        width: "900px",
+        bgcolor: "rgba(0,0,0,0.3)",
+        mb: 1,
+        px: 2,
+        pb: 1,
+        borderRadius: 4,
+        minHeight: "210px",
+        maxHeight: "250px",
+      }}
+    >
+      <Typography
+        textAlign="left"
+        id="showMember"
+        sx={{
+          mt: 1,
+          pt: 1,
+          mb: 1,
+          mx: 1,
+          fontSize: "20px",
+        }}
+      >
+        {title}
+      </Typography>
+      <Box
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          maxHeight: "200px",
+          overflow: "scroll",
+          overflowX: "hidden",
+        }}
+      >
+        {children}
+      </Box>
+    </Box>
+  )
+}
+
+export default TitleWrapper

--- a/src/components/workspace/list/WorkspaceCard.tsx
+++ b/src/components/workspace/list/WorkspaceCard.tsx
@@ -1,0 +1,95 @@
+import React from "react"
+import {
+  Card,
+  CardContent,
+  CardMedia,
+  Typography,
+  CardActionArea,
+  Box,
+} from "@mui/material"
+import { Link as RouterLink } from "react-router-dom"
+
+interface WorkspaceItemProps {
+  wsTitle: string
+  imgUrl: string
+  division: string
+  to: string
+}
+
+const WorkspaceCard: React.FC<WorkspaceItemProps> = ({
+  wsTitle,
+  imgUrl,
+  division,
+  to,
+}) => {
+  return (
+    <Card sx={{ maxWidth: "250px", height: "140px", my: 1, mx: "20px" }}>
+      <CardActionArea component={RouterLink} to={to}>
+        <Box
+          sx={{
+            display: "flex",
+            padding: 1,
+          }}
+        >
+          <Box
+            sx={{
+              widht: "100px",
+              marginX: "auto",
+              pr: "10px",
+              borderRight: "1px solid skyblue",
+            }}
+          >
+            <Box
+              component="span"
+              sx={{
+                display: "block",
+                width: "90px",
+                height: "30px",
+                bgcolor: "skyblue",
+                color: "white",
+                borderRadius: 2,
+                boxSizing: "border-box",
+                textAlign: "center",
+                lineHeight: "30px",
+                fontSize: "16px",
+              }}
+            >
+              {division}
+            </Box>
+            <CardMedia
+              component="img"
+              sx={{
+                height: "110px",
+                width: "90px",
+                objectFit: "cover",
+              }}
+              image={imgUrl}
+              alt={wsTitle}
+            />
+          </Box>
+          <CardContent
+            sx={{
+              height: "110px",
+              width: "150px",
+            }}
+          >
+            <Typography
+              gutterBottom
+              variant="h5"
+              component="div"
+              sx={{
+                overflow: "hidden",
+                whiteSpace: "pre-line",
+                fontSize: "16px",
+              }}
+            >
+              {wsTitle}
+            </Typography>
+          </CardContent>
+        </Box>
+      </CardActionArea>
+    </Card>
+  )
+}
+
+export default WorkspaceCard

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,63 +1,18 @@
 import React from "react"
-import Title from "components/common/Title"
 import { TEST_IMAGE_URL } from "env"
 import styled from "styled-components"
 import Header from "components/header/Header"
+import TitleWrapper from "components/workspace/list/TitleWrapper"
+import { Box } from "@mui/material"
+import WorkspaceCard from "components/workspace/list/WorkspaceCard"
 
 const DefaultLayout = styled.div`
   width: 100%;
   height: 100vh;
   overflow: hidden;
 `
-
-const WorkspaceInfoWrapper = styled.div`
-  display: flex;
-  position: relative;
-  align-items: center;
-  width: 200px;
-  height: 100px;
-  border: 1px solid black;
-  margin: 8px;
-`
-
-const WorkspaceTitle = styled.h3`
-  width: 60%;
-  height: 20%;
-  text-align: center;
-  background-color: rgba(255, 255, 255, 0.3);
-`
-
-const WorkspaceImg = styled.img`
-  border-radius: 50%;
-  height: 60px;
-  width: 60px;
-  border: 1px solid black;
-  text-align: center;
-  font-size: 80px;
-  margin: 0 8px;
-`
-
-const WorkpaceDivision = styled.p`
-  position: absolute;
-  top: 0;
-  right: 0;
-  padding: 4px;
-  margin: 4px;
-  background-color: rgba(0, 0, 0, 0.5);
-`
-
-const WorkspaceListWrapper = styled.ul`
-  display: flex;
-`
-
 interface WorkspaceData {
   workspaceId: number
-  title: string
-  imgUrl: string
-  division: string
-}
-
-interface WorkspaceItemProps {
   title: string
   imgUrl: string
   division: string
@@ -76,42 +31,77 @@ const dummyData: WorkspaceData[] = [
     imgUrl: `${TEST_IMAGE_URL}`,
     division: "그룹",
   },
+  {
+    workspaceId: 3,
+    title: "워크스페이스 3",
+    imgUrl: `${TEST_IMAGE_URL}`,
+    division: "그룹",
+  },
+  {
+    workspaceId: 4,
+    title: "워크스페이스 4",
+    imgUrl: `${TEST_IMAGE_URL}`,
+    division: "그룹",
+  },
+  {
+    workspaceId: 5,
+    title: "워크스페이스 5",
+    imgUrl: `${TEST_IMAGE_URL}`,
+    division: "그룹",
+  },
+  {
+    workspaceId: 6,
+    title: "워크스페이스 6",
+    imgUrl: `${TEST_IMAGE_URL}`,
+    division: "그룹",
+  },
 ]
 
-const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
-  title,
-  imgUrl,
-  division,
-}) => {
-  return (
-    <WorkspaceInfoWrapper>
-      <WorkspaceImg src={imgUrl} alt={title} />
-      <WorkspaceTitle className="ws_title">{title}</WorkspaceTitle>
-      <WorkpaceDivision>{division}</WorkpaceDivision>
-    </WorkspaceInfoWrapper>
-  )
-}
-
 const Home: React.FC = () => {
+  const uniqueDivisions = Array.from(
+    new Set(dummyData.map(item => item.division)),
+  )
+
   return (
     <DefaultLayout>
       <Header />
-      <Title title="HOME" subtitle="워크스페이스 목록" />
-      <section>
-        <WorkspaceListWrapper>
-          {dummyData.map(workspace => (
-            <li>
-              <WorkspaceItem
-                key={workspace.workspaceId}
-                title={workspace.title}
-                imgUrl={workspace.imgUrl}
-                division={workspace.division}
-              />
-            </li>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          mt: 6,
+        }}
+      >
+        <Box>
+          <Box
+            component="div"
+            sx={{
+              fontSize: "32px",
+            }}
+          >
+            워크스페이스 목록
+          </Box>
+
+          {uniqueDivisions.map(division => (
+            <TitleWrapper key={division} title={division}>
+              {dummyData
+                .filter(item => item.division === division)
+                .map(workspace => (
+                  <WorkspaceCard
+                    key={workspace.workspaceId}
+                    wsTitle={workspace.title}
+                    imgUrl={workspace.imgUrl}
+                    division={workspace.division}
+                    to={`/workspace/${String(workspace.workspaceId)}`}
+                  />
+                ))}
+            </TitleWrapper>
           ))}
-        </WorkspaceListWrapper>
-      </section>
+        </Box>
+      </Box>
     </DefaultLayout>
   )
 }
+
 export default Home


### PR DESCRIPTION
[https://github.com/Daon-sy/daon-frontend/issues/66]
워크스페이스 카드 Wrapper의 경우, 워크스페이스 목록 뿐 아니라 프로젝트 목록에서도 사용되는 컴포넌트라 공통으로 뽑는건 어떨까싶어 TitleWrapper로 네이밍하였습니다