### PR TITLE
리스트 버튼 공통 컴포넌트 작성

### DIFF
--- a/src/components/common/SelectListButton.tsx
+++ b/src/components/common/SelectListButton.tsx
@@ -1,0 +1,169 @@
+import React from "react"
+import {
+  Menu,
+  Button,
+  Fade,
+  MenuItem,
+  MenuProps,
+  Box,
+  Chip,
+} from "@mui/material"
+import { styled } from "@mui/material/styles"
+
+const StyledMenu = styled((props: MenuProps) => (
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  <Menu elevation={0} {...props} />
+))(({ theme }) => ({
+  "& .MuiPaper-root": {
+    borderRadius: 6,
+    marginTop: theme.spacing(1),
+    minWidth: 100,
+    color:
+      theme.palette.mode === "light"
+        ? "rgb(55, 65, 81)"
+        : theme.palette.grey[300],
+    boxShadow:
+      "rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px",
+    "& .MuiMenu-list": {
+      padding: "4px 0",
+    },
+    "& .MuiMenuItem-root": {
+      "& .MuiSvgIcon-root": {
+        fontSize: 18,
+        color: theme.palette.text.secondary,
+        marginRight: theme.spacing(1.5),
+      },
+    },
+  },
+}))
+
+export interface ItemType {
+  id: number
+  text: string
+  color?: "info" | "primary" | "success" | "warning"
+}
+
+interface Props<T extends ItemType> {
+  unsetButtonText?: string
+  valueList?: Array<T> | undefined
+  defaultValueId?: number | undefined
+  showClearListItem?: true | false
+  leftMuiIcon?: React.ReactNode | undefined
+  endMuiIcon?: React.ReactNode | undefined
+  onValueChange?: (selectedValue: T) => void | undefined
+  itemToChip?: true | false
+  changeButtonColor?: true | false
+  disableChangeButtonText?: true | false
+  variant?: "outlined" | "contained"
+}
+
+const SelectListButton = <T extends ItemType>({
+  unsetButtonText = "",
+  valueList,
+  defaultValueId = undefined,
+  showClearListItem = false,
+  leftMuiIcon,
+  endMuiIcon,
+  onValueChange,
+  itemToChip = false,
+  changeButtonColor = false,
+  disableChangeButtonText = false,
+  variant = "outlined",
+}: Props<T>) => {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const open = Boolean(anchorEl)
+  const openList = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const findValueById = (valueId: number) =>
+    valueList?.find(item => item.id === valueId)
+
+  const [selectedValue, setSelectedValue] = React.useState<T | undefined>()
+
+  React.useEffect(() => {
+    if (defaultValueId) setSelectedValue(findValueById(defaultValueId))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const close = () => setAnchorEl(null)
+  const handleClickedItem = (event: React.MouseEvent<HTMLElement>) => {
+    const id = Number(event.currentTarget.getAttribute("value"))
+    const value = findValueById(id)
+    if (!disableChangeButtonText) setSelectedValue(value)
+    if (onValueChange && value) onValueChange(value)
+    close()
+  }
+
+  return (
+    <Box>
+      <Button
+        aria-controls={open ? "fade-menu" : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        onClick={openList}
+        variant={variant}
+        disableElevation
+        color={
+          changeButtonColor && selectedValue && selectedValue.color
+            ? (selectedValue.color as
+                | "info"
+                | "primary"
+                | "success"
+                | "warning")
+            : "info"
+        }
+        endIcon={endMuiIcon}
+        sx={{
+          px: 1,
+        }}
+      >
+        {leftMuiIcon}
+        <Box pl={leftMuiIcon ? 1 : 0}>
+          {selectedValue ? selectedValue.text : unsetButtonText}
+        </Box>
+      </Button>
+      <StyledMenu
+        anchorEl={anchorEl}
+        MenuListProps={{
+          "aria-labelledby": "demo-customized-button",
+        }}
+        open={open}
+        onClose={close}
+        TransitionComponent={Fade}
+      >
+        {selectedValue && showClearListItem ? (
+          <MenuItem onClick={handleClickedItem}>{unsetButtonText}</MenuItem>
+        ) : null}
+        {valueList
+          ?.filter(item => item.id !== selectedValue?.id)
+          .map(item => (
+            <MenuItem onClick={handleClickedItem} value={item.id}>
+              {itemToChip && item.color ? (
+                <Chip
+                  label={item.text}
+                  size="small"
+                  color={
+                    item.color
+                      ? (item.color as
+                          | "info"
+                          | "primary"
+                          | "success"
+                          | "warning")
+                      : "info"
+                  }
+                  sx={{
+                    fontSize: 12,
+                  }}
+                />
+              ) : (
+                item.text
+              )}
+            </MenuItem>
+          ))}
+      </StyledMenu>
+    </Box>
+  )
+}
+
+export default SelectListButton

--- a/src/components/modal/task/TaskCreateModal.tsx
+++ b/src/components/modal/task/TaskCreateModal.tsx
@@ -33,8 +33,8 @@ const TaskCreateModal: React.FC<Props> = ({ open, handleClose }: Props) => {
           }}
         >
           <Stack direction="row" spacing={2}>
-            <ProjectSelectButton current="프로젝트 선택" />
-            <BoardSelectButton current="보드 선택" />
+            <ProjectSelectButton />
+            <BoardSelectButton />
           </Stack>
           <Box flexGrow={1} />
           <Box

--- a/src/components/modal/task/TaskDetailModal.tsx
+++ b/src/components/modal/task/TaskDetailModal.tsx
@@ -90,7 +90,7 @@ const TaskDetailModal: React.FC<Props> = ({
                   paddingLeft: 1,
                 }}
               >
-                <BoardSelectButton current={task.board.name} />
+                <BoardSelectButton current={task.board} />
                 <Box flexGrow={1} />
                 <Box
                   sx={{

--- a/src/components/task/BoardSelectButton.tsx
+++ b/src/components/task/BoardSelectButton.tsx
@@ -1,80 +1,35 @@
 import React from "react"
-import { Menu, Button, Fade, MenuItem, MenuProps, Box } from "@mui/material"
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown"
-import { styled } from "@mui/material/styles"
 import FolderIcon from "@mui/icons-material/Folder"
-
-const StyledMenu = styled((props: MenuProps) => (
-  // eslint-disable-next-line react/jsx-props-no-spreading
-  <Menu elevation={0} {...props} />
-))(({ theme }) => ({
-  "& .MuiPaper-root": {
-    borderRadius: 6,
-    marginTop: theme.spacing(1),
-    minWidth: 120,
-    color:
-      theme.palette.mode === "light"
-        ? "rgb(55, 65, 81)"
-        : theme.palette.grey[300],
-    boxShadow:
-      "rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px",
-    "& .MuiMenu-list": {
-      padding: "4px 0",
-    },
-    "& .MuiMenuItem-root": {
-      "& .MuiSvgIcon-root": {
-        fontSize: 18,
-        color: theme.palette.text.secondary,
-        marginRight: theme.spacing(1.5),
-      },
-    },
-  },
-}))
+import SelectListButton from "components/common/SelectListButton"
+import { Board } from "_types/TaskType"
 
 interface Props {
-  current: string
+  current?: Board
 }
 
 const BoardSelectButton: React.FC<Props> = ({ current }: Props) => {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl)
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget)
-  }
-  const handleClose = (e: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(null)
-  }
+  const listItems = [
+    {
+      id: 1,
+      text: "Board1",
+    },
+    {
+      id: 2,
+      text: "Board2",
+    },
+  ]
 
   return (
-    <div>
-      <Button
-        aria-controls={open ? "fade-menu" : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? "true" : undefined}
-        onClick={handleClick}
-        variant="outlined"
-        disableElevation
-        endIcon={<KeyboardArrowDownIcon />}
-        sx={{
-          px: 1,
-        }}
-      >
-        <FolderIcon />
-        <Box pl={1}>{current}</Box>
-      </Button>
-      <StyledMenu
-        anchorEl={anchorEl}
-        MenuListProps={{
-          "aria-labelledby": "demo-customized-button",
-        }}
-        open={open}
-        onClose={handleClose}
-        TransitionComponent={Fade}
-      >
-        <MenuItem onClick={handleClose}>Board1</MenuItem>
-        <MenuItem onClick={handleClose}>Board2</MenuItem>
-      </StyledMenu>
-    </div>
+    <SelectListButton
+      unsetButtonText="보드 선택"
+      showClearListItem
+      defaultValueId={current?.boardId}
+      valueList={listItems}
+      leftMuiIcon={<FolderIcon />}
+      endMuiIcon={<KeyboardArrowDownIcon />}
+      onValueChange={selectedValue => console.log(selectedValue)}
+    />
   )
 }
 

--- a/src/components/task/ProgressSelectButton.tsx
+++ b/src/components/task/ProgressSelectButton.tsx
@@ -1,128 +1,55 @@
 import React from "react"
-import { Menu, Button, Fade, MenuItem, MenuProps, Chip } from "@mui/material"
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown"
-import { styled } from "@mui/material/styles"
+import SelectListButton, { ItemType } from "components/common/SelectListButton"
 
-const StyledMenu = styled((props: MenuProps) => (
-  // eslint-disable-next-line react/jsx-props-no-spreading
-  <Menu elevation={0} {...props} />
-))(({ theme }) => ({
-  "& .MuiPaper-root": {
-    borderRadius: 6,
-    marginTop: theme.spacing(1),
-    minWidth: 80,
-    color:
-      theme.palette.mode === "light"
-        ? "rgb(55, 65, 81)"
-        : theme.palette.grey[300],
-    boxShadow:
-      "rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px",
-    "& .MuiMenu-list": {
-      padding: "4px 0",
-    },
-    "& .MuiMenuItem-root": {
-      "& .MuiSvgIcon-root": {
-        fontSize: 18,
-        color: theme.palette.text.secondary,
-        marginRight: theme.spacing(1.5),
-      },
-    },
-  },
-}))
-
-interface Status {
+interface Status extends ItemType {
   value: string
-  description: string
-  color: "info" | "primary" | "success" | "warning"
 }
-
-const status: Array<Status> = [
-  {
-    value: "TODO",
-    description: "할 일",
-    color: "info",
-  },
-  {
-    value: "PROCEEDING",
-    description: "진행중",
-    color: "primary",
-  },
-  {
-    value: "COMPLETED",
-    description: "완료됨",
-    color: "success",
-  },
-  {
-    value: "PENDING",
-    description: "보류중",
-    color: "warning",
-  },
-]
 
 interface Props {
   current: string
 }
 
+const TODO: Status = {
+  id: 1,
+  text: "할 일",
+  value: "TODO",
+  color: "info",
+}
+const PROCEEDING: Status = {
+  id: 2,
+  text: "진행중",
+  value: "PROCEEDING",
+  color: "primary",
+}
+const COMPLETED: Status = {
+  id: 3,
+  text: "완료됨",
+  value: "COMPLETED",
+  color: "success",
+}
+const PENDING: Status = {
+  id: 4,
+  text: "보류중",
+  value: "PENDING",
+  color: "warning",
+}
+
 const ProgressSelectButton: React.FC<Props> = ({ current }: Props) => {
-  const getStatusItem = (value: string) =>
-    status.find(item => item.value === value)
+  const listItems = [TODO, PROCEEDING, COMPLETED, PENDING]
 
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const [selected, setSelected] = React.useState<Status>(
-    getStatusItem(current)!,
-  )
-  const open = Boolean(anchorEl)
-
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget)
-  }
-
-  // TODO 메뉴 열고 선택 안하면 오류 발생
-  const handleClose = (e: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(null)
-    const value = e.currentTarget.getAttribute("value")
-    setSelected(getStatusItem(value!)!)
-  }
+  const foundData = listItems.find(item => item.value === current)
 
   return (
-    <div>
-      <Button
-        aria-controls={open ? "fade-menu" : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? "true" : undefined}
-        onClick={handleClick}
-        variant="contained"
-        color={selected.color}
-        disableElevation
-        endIcon={<KeyboardArrowDownIcon />}
-      >
-        {selected.description}
-      </Button>
-      <StyledMenu
-        anchorEl={anchorEl}
-        MenuListProps={{
-          "aria-labelledby": "demo-customized-button",
-        }}
-        open={open}
-        onClose={handleClose}
-        TransitionComponent={Fade}
-      >
-        {status
-          .filter(item => item.value !== selected.value)
-          .map(item => (
-            <MenuItem onClick={handleClose} value={item.value}>
-              <Chip
-                label={item.description}
-                size="small"
-                color={item.color}
-                sx={{
-                  fontSize: 12,
-                }}
-              />
-            </MenuItem>
-          ))}
-      </StyledMenu>
-    </div>
+    <SelectListButton
+      itemToChip
+      changeButtonColor
+      defaultValueId={foundData?.id || TODO.id}
+      valueList={listItems}
+      endMuiIcon={<KeyboardArrowDownIcon />}
+      onValueChange={selectedValue => console.log(selectedValue.value)}
+      variant="contained"
+    />
   )
 }
 

--- a/src/components/task/ProjectSelectButton.tsx
+++ b/src/components/task/ProjectSelectButton.tsx
@@ -1,80 +1,28 @@
 import React from "react"
-import { Menu, Button, Fade, MenuItem, MenuProps, Box } from "@mui/material"
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown"
-import { styled } from "@mui/material/styles"
 import DvrIcon from "@mui/icons-material/Dvr"
+import SelectListButton from "components/common/SelectListButton"
 
-const StyledMenu = styled((props: MenuProps) => (
-  // eslint-disable-next-line react/jsx-props-no-spreading
-  <Menu elevation={0} {...props} />
-))(({ theme }) => ({
-  "& .MuiPaper-root": {
-    borderRadius: 6,
-    marginTop: theme.spacing(1),
-    minWidth: 120,
-    color:
-      theme.palette.mode === "light"
-        ? "rgb(55, 65, 81)"
-        : theme.palette.grey[300],
-    boxShadow:
-      "rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px",
-    "& .MuiMenu-list": {
-      padding: "4px 0",
+const ProjectSelectButton: React.FC = () => {
+  const listItems = [
+    {
+      id: 1,
+      text: "Project1",
     },
-    "& .MuiMenuItem-root": {
-      "& .MuiSvgIcon-root": {
-        fontSize: 18,
-        color: theme.palette.text.secondary,
-        marginRight: theme.spacing(1.5),
-      },
+    {
+      id: 2,
+      text: "Project2",
     },
-  },
-}))
-
-interface Props {
-  current: string
-}
-
-const ProjectSelectButton: React.FC<Props> = ({ current }: Props) => {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl)
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget)
-  }
-  const handleClose = (e: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(null)
-  }
+  ]
 
   return (
-    <div>
-      <Button
-        aria-controls={open ? "fade-menu" : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? "true" : undefined}
-        onClick={handleClick}
-        variant="outlined"
-        disableElevation
-        endIcon={<KeyboardArrowDownIcon />}
-        sx={{
-          px: 1,
-        }}
-      >
-        <DvrIcon />
-        <Box pl={1}>{current}</Box>
-      </Button>
-      <StyledMenu
-        anchorEl={anchorEl}
-        MenuListProps={{
-          "aria-labelledby": "demo-customized-button",
-        }}
-        open={open}
-        onClose={handleClose}
-        TransitionComponent={Fade}
-      >
-        <MenuItem onClick={handleClose}>Project1</MenuItem>
-        <MenuItem onClick={handleClose}>Project2</MenuItem>
-      </StyledMenu>
-    </div>
+    <SelectListButton
+      unsetButtonText="프로젝트 선택"
+      valueList={listItems}
+      leftMuiIcon={<DvrIcon />}
+      endMuiIcon={<KeyboardArrowDownIcon />}
+      onValueChange={selectedValue => console.log(selectedValue)}
+    />
   )
 }
 


### PR DESCRIPTION
- 클릭시 리스트 아이템을 보여주는 버튼 컴포넌트 작성 <SelectListButton>
- 아이콘 삽입 가능
- 아이템 선택시 콜백 메서드 지정 가능

SelectListButton의 props는 다음과 같습니다.
```javascript
export interface ItemType {
  id: number
  text: string
  color?: "info" | "primary" | "success" | "warning"
}

interface Props<T extends ItemType> {
  unsetButtonText?: string
  valueList?: Array<T> | undefined
  defaultValueId?: number | undefined
  showClearListItem?: true | false
  leftMuiIcon?: React.ReactNode | undefined
  endMuiIcon?: React.ReactNode | undefined
  onValueChange?: (selectedValue: T) => void | undefined
  itemToChip?: true | false
  changeButtonColor?: true | false
  disableChangeButtonText?: true | false
  variant?: "outlined" | "contained"
}
```

아래는 Props 속성의 설명입니다.
- `unsetButtonText` : 아이템 미선택시, 버튼에 보여줄 텍스트입니다.
- `valueList` : 버튼 클릭시 리스트에 보여줄 아이템들입니다. ItemType을 구현한 타입이어야 합니다.
- `defaultValueId` : valueList에서 기본으로 선택될 id를 지정합니다. 지정하지 않으면 `unsetButtonText`를 버튼에 출력합니다.
- `showClearListItem` : 선택한 아이템을 선택 해제 가능하도록 하는 아이템을 리스트에 출력할지 지정합니다.
- `leftMuiIcon` : 버튼 좌측에 보여줄 Icon 입니다.
- `endMuiIcon` : 버튼 끝측에 보여줄 Icon 입니다.
- `onValueChange` : 아이템이 선택되었을 때 수행할 콜백 함수를 지정합니다.
- `itemToChip` : 아이템들을 Mui Chip 컴포넌트로 보여줄지 지정합니다.
- `changeButtonColor` : 아이템이 선택되었을 때, 아이템의 color 속성으로 버튼 색을 변경할지 지정합니다.
- `disableChangeButtonText` : 아이템 선택시, 버튼의 텍스트를 해당 아이템의 text 속성으로 변경할지 지정합니다.
- `variant` : 버튼의 타입을 지정합니다.