### PR TITLE
react-beautiful-dnd 로 drag and drop 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "mem": "^9.0.2",
         "notistack": "^3.0.1",
         "react": "^18.2.0",
+        "react-beautiful-dnd": "^13.1.1",
         "react-cookie": "^6.1.1",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.17.0",
@@ -40,6 +41,7 @@
       },
       "devDependencies": {
         "@craco/types": "^7.1.0",
+        "@types/react-beautiful-dnd": "^13.1.7",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "craco-plugin-env": "^1.0.5",
@@ -4872,12 +4874,32 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/react-beautiful-dnd": {
+      "version": "13.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react-beautiful-dnd/-/react-beautiful-dnd-13.1.7.tgz",
+      "integrity": "sha512-jQZLov9OkD0xRQkqz8/lx66bHYAYv+g4+POBqnH5Jtt/xo4MygzM879Q9sxAiosPBdNj1JYTdbPxDn3dNRYgow==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react-dom": {
       "version": "18.2.14",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.14.tgz",
       "integrity": "sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.30",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.30.tgz",
+      "integrity": "sha512-i2kqM6YaUwFKduamV6QM/uHbb0eCP8f8ZQ/0yWf+BsAVVsZPRYJ9eeGWZ3uxLfWwwA0SrPRMTPTqsPFkY3HZdA==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -7036,6 +7058,14 @@
       },
       "peerDependencies": {
         "postcss": "^8.4"
+      }
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "node_modules/css-color-keywords": {
@@ -13502,6 +13532,11 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -15804,6 +15839,11 @@
         "performance-now": "^2.1.0"
       }
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -15884,6 +15924,24 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
+    "node_modules/react-beautiful-dnd": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
+      "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2",
+        "css-box-model": "^1.2.0",
+        "memoize-one": "^5.1.1",
+        "raf-schd": "^4.0.2",
+        "react-redux": "^7.2.0",
+        "redux": "^4.0.4",
+        "use-memo-one": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/react-cookie": {
       "version": "6.1.1",
@@ -16036,6 +16094,30 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-redux": {
+      "version": "7.2.9",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
+      "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/react-redux": "^7.1.20",
+        "hoist-non-react-statics": "^3.3.2",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -16223,6 +16305,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -17945,6 +18035,11 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+    },
     "node_modules/titleize": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
@@ -18428,6 +18523,14 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "mem": "^9.0.2",
     "notistack": "^3.0.1",
     "react": "^18.2.0",
+    "react-beautiful-dnd": "^13.1.1",
     "react-cookie": "^6.1.1",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.17.0",
@@ -65,6 +66,7 @@
   },
   "devDependencies": {
     "@craco/types": "^7.1.0",
+    "@types/react-beautiful-dnd": "^13.1.7",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "craco-plugin-env": "^1.0.5",

--- a/src/components/task/kanban/TaskCard.tsx
+++ b/src/components/task/kanban/TaskCard.tsx
@@ -59,7 +59,7 @@ interface Props {
   task: TaskSummary
 }
 
-const TaskCard: React.FC<Props> = ({ task }: Props) => {
+const TaskCard: React.FC<Props> = React.memo(({ task }: Props) => {
   const [detailModalOpen, setDetailModalOpen] = React.useState(false)
 
   return (
@@ -136,6 +136,5 @@ const TaskCard: React.FC<Props> = ({ task }: Props) => {
       />
     </>
   )
-}
-
+})
 export default TaskCard

--- a/src/components/task/kanban/TaskCard.tsx
+++ b/src/components/task/kanban/TaskCard.tsx
@@ -68,7 +68,6 @@ const TaskCard: React.FC<Props> = ({ task }: Props) => {
         sx={{
           m: 1,
         }}
-        draggable
       >
         <EmergencyTag render={task.emergency} />
         <Card

--- a/src/components/task/kanban/TaskKanbanBoard.tsx
+++ b/src/components/task/kanban/TaskKanbanBoard.tsx
@@ -1,13 +1,16 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import React from "react"
 import Box from "@mui/material/Box"
 import { Chip, Divider } from "@mui/material"
 import TaskCard from "components/task/kanban/TaskCard"
 import { TaskSummary } from "_types/task"
+import { Droppable, Draggable } from "react-beautiful-dnd"
 
 interface Props {
   title: string
   dividerColor: string | null
   style: React.CSSProperties
+  progressStatus: string
   tasks: Array<TaskSummary>
 }
 
@@ -16,57 +19,81 @@ const TaskKanbanBoard: React.FC<Props> = ({
   dividerColor,
   style,
   tasks,
+  progressStatus,
 }: Props) => {
-  const renderTaskCards = () => tasks.map(task => <TaskCard task={task} />)
-
   return (
-    <Box style={style}>
-      <Box
-        sx={{
-          fontSize: 24,
-          fontWeight: 500,
-          paddingLeft: 0.5,
-          paddingBottom: 2,
-          margin: 0.5,
-        }}
-      >
-        {title}
-        <Chip
-          label={tasks.length}
-          variant="outlined"
-          size="small"
-          sx={{
-            marginLeft: 2,
-            paddingX: 1,
-            color: "rgba(150, 150, 150)",
-          }}
-        />
-      </Box>
-      <Box
-        sx={{
-          margin: 0.5,
-        }}
-      >
-        <Divider
-          sx={{
-            border: "2px solid",
-            borderColor: dividerColor,
-          }}
-        />
-      </Box>
-      <Box
-        sx={{
-          margin: 1,
-          marginTop: 2.5,
-          paddingY: 0.1,
-          backgroundColor: "rgba(242, 246, 252)",
-          borderRadius: 2,
-          height: "100%",
-        }}
-      >
-        {renderTaskCards()}
-      </Box>
-    </Box>
+    <Droppable droppableId={progressStatus}>
+      {droppableProvided => (
+        <Box
+          ref={droppableProvided.innerRef}
+          {...droppableProvided.droppableProps}
+          style={style}
+        >
+          <Box
+            sx={{
+              fontSize: 24,
+              fontWeight: 500,
+              paddingLeft: 0.5,
+              paddingBottom: 2,
+              margin: 0.5,
+            }}
+          >
+            {title}
+            <Chip
+              label={tasks.length}
+              variant="outlined"
+              size="small"
+              sx={{
+                marginLeft: 2,
+                paddingX: 1,
+                color: "rgba(150, 150, 150)",
+              }}
+            />
+          </Box>
+          <Box
+            sx={{
+              margin: 0.5,
+            }}
+          >
+            <Divider
+              sx={{
+                border: "2px solid",
+                borderColor: dividerColor,
+              }}
+            />
+          </Box>
+          <Box
+            sx={{
+              margin: 1,
+              marginTop: 2.5,
+              paddingY: 0.1,
+              backgroundColor: "rgba(242, 246, 252)",
+              borderRadius: 2,
+              height: "100%",
+            }}
+          >
+            {tasks.map((task, index) => (
+              <Draggable
+                key={task.taskId}
+                draggableId={String(task.taskId)}
+                index={index}
+              >
+                {draggableProvided => (
+                  <div
+                    ref={draggableProvided.innerRef}
+                    {...draggableProvided.draggableProps}
+                    {...draggableProvided.dragHandleProps}
+                  >
+                    <TaskCard task={task} />
+                  </div>
+                )}
+              </Draggable>
+            ))}
+            {droppableProvided.placeholder}
+          </Box>
+        </Box>
+      )}
+    </Droppable>
   )
 }
 

--- a/src/components/task/kanban/TaskKanbansWrapper.tsx
+++ b/src/components/task/kanban/TaskKanbansWrapper.tsx
@@ -1,8 +1,10 @@
-import React from "react"
+import React, { useState, useEffect } from "react"
 import Box from "@mui/material/Box"
 import { Stack } from "@mui/material"
 import TaskKanbanBoard from "components/task/kanban/TaskKanbanBoard"
-import { TaskSummary } from "_types/task"
+import { TaskSummary, TASK_STATUS } from "_types/task"
+import { DragDropContext, DropResult } from "react-beautiful-dnd"
+import { modifyTaskProgressStatusApi } from "api/task"
 
 interface TaskKanbansWrapperProps {
   tasks: TaskSummary[]
@@ -30,7 +32,38 @@ const list = [
   },
 ]
 
+const workspaceId = location.pathname.split("/")[2]
 const TaskKanbansWrapper: React.FC<TaskKanbansWrapperProps> = ({ tasks }) => {
+  const [updateTasks, setUpdateTask] = useState<TaskSummary[]>([])
+
+  useEffect(() => {
+    setUpdateTask(tasks)
+  }, [tasks])
+
+  const handleDragEnd = (result: DropResult) => {
+    if (!result.destination) {
+      return
+    }
+    const { destination, draggableId } = result
+    const updatedTasks = [...updateTasks]
+    const movedTaskIndex = updatedTasks.findIndex(
+      task => task.taskId === +draggableId,
+    )
+    const movedTask = updatedTasks[movedTaskIndex]
+    updatedTasks.splice(movedTaskIndex, 1)
+    updatedTasks.splice(destination.index, 0, movedTask)
+    movedTask.progressStatus = destination.droppableId as TASK_STATUS
+    // API 호출 및 업데이트
+    modifyTaskProgressStatusApi(
+      +workspaceId,
+      movedTask.project.projectId,
+      movedTask.taskId,
+      {
+        ...movedTask,
+      },
+    )
+    setUpdateTask(updatedTasks)
+  }
   const renderKanbanBoards = () =>
     list.map(item => (
       <TaskKanbanBoard
@@ -38,36 +71,39 @@ const TaskKanbansWrapper: React.FC<TaskKanbansWrapperProps> = ({ tasks }) => {
         title={item.title}
         style={{ width: "100%" }}
         dividerColor={item.dividerColor}
-        tasks={tasks.filter(
+        progressStatus={item.progressStatus}
+        tasks={updateTasks.filter(
           task => task.progressStatus === item.progressStatus && task !== null,
         )}
       />
     ))
 
   return (
-    <Box
-      sx={{
-        paddingRight: 5,
-        width: "100%",
-        height: "80%",
-        minHeight: "555px",
-        overflow: "scroll",
-        overflowX: "hidden",
-        marginTop: 2,
-      }}
-    >
-      <Stack
-        direction="row"
+    <DragDropContext onDragEnd={handleDragEnd}>
+      <Box
         sx={{
+          paddingRight: 5,
           width: "100%",
-          padding: 1,
+          height: "80%",
+          minHeight: "555px",
+          overflow: "scroll",
+          overflowX: "hidden",
           marginTop: 2,
         }}
-        spacing={2}
       >
-        {renderKanbanBoards()}
-      </Stack>
-    </Box>
+        <Stack
+          direction="row"
+          sx={{
+            width: "100%",
+            padding: 1,
+            marginTop: 2,
+          }}
+          spacing={2}
+        >
+          {renderKanbanBoards()}
+        </Stack>
+      </Box>
+    </DragDropContext>
   )
 }
 

--- a/src/components/task/kanban/TaskKanbansWrapper.tsx
+++ b/src/components/task/kanban/TaskKanbansWrapper.tsx
@@ -33,7 +33,9 @@ const list = [
   },
 ]
 
-const TaskKanbansWrapper: React.FC<TaskKanbansWrapperProps> = ({ tasks }) => {
+const TaskKanbansWrapper: React.FC<TaskKanbansWrapperProps> = ({
+  tasks,
+}: TaskKanbansWrapperProps) => {
   const workspaceId = location.pathname.split("/")[2]
   const [updateTasks, setUpdateTask] = useState<TaskSummary[]>([])
 

--- a/src/components/task/kanban/TaskKanbansWrapper.tsx
+++ b/src/components/task/kanban/TaskKanbansWrapper.tsx
@@ -9,6 +9,7 @@ import { modifyTaskProgressStatusApi } from "api/task"
 interface TaskKanbansWrapperProps {
   tasks: TaskSummary[]
 }
+
 const list = [
   {
     progressStatus: "TODO",
@@ -32,8 +33,8 @@ const list = [
   },
 ]
 
-const workspaceId = location.pathname.split("/")[2]
 const TaskKanbansWrapper: React.FC<TaskKanbansWrapperProps> = ({ tasks }) => {
+  const workspaceId = location.pathname.split("/")[2]
   const [updateTasks, setUpdateTask] = useState<TaskSummary[]>([])
 
   useEffect(() => {


### PR DESCRIPTION
### react-beautiful-dnd 적용

- DragDropContext : dnd를 사용하고자 하는 영역을 감싸는 Wrapper
- Droppable : dnd에서 drop을 할 수 있는 영역이자, Draggable을 감싸는 Wrapper
- Draggable : dnd의 주체가 되는, drag가 가능한 컴포넌트를 감싸는 Wrapper

**컴포넌트 적용**
- `<TaskKanbansWrapper />` : DragDropContext
- `<TaskKanbanBoard />`: Droppable
- `<TaskCard />` : Draggable

---
```
react-beautiful-dnd의 경우 spread 연산자를 사용하였습니다.

> react-beautiful-dnd 라이브러리는 내부적으로 프롭스를 효과적으로 처리하여 성능 최적화를 하고 있기때문에 
> `/* eslint-disable react/jsx-props-no-spreading */` 해당 ESLint규칙을 비활성화 하였습니다.
```

```
성능최적화를 위한 React.memo의 적용
React.memo를 통해 이전에 계산한 결과를 재사용하여 성능을 향상시킬 수 있지 않을까? 라는 의문을 가지고 `<TaskCard />`에 적용
적용 후, draggable 컴포넌트를 이동할 때 리렌더링이 발생하지 않음을 확인하였음
```

- 적용전
![image](https://github.com/Daon-sy/daon-frontend/assets/109890241/b49594f7-8093-46e9-9280-563a0ac64079)

- 적용후
![image](https://github.com/Daon-sy/daon-frontend/assets/109890241/977eb5d2-b5ab-4cea-98f3-d7926d5afb68)



