### PR TITLE
🔨[refactor] 쪽지 API 관련 수정

### DIFF
--- a/src/_types/workspace/index.ts
+++ b/src/_types/workspace/index.ts
@@ -64,7 +64,7 @@ export interface MessageSummary {
   content: string
   createdAt: string
   readed: boolean
-  sender: MessageSender
+  sender?: MessageSender
 }
 
 export type ColorRole = { color: ColorOptions } & WorkspaceParticipantRoleDetail

--- a/src/components/message/MessageCard.tsx
+++ b/src/components/message/MessageCard.tsx
@@ -42,8 +42,8 @@ const MessageCard: React.FC<MessageCardProps> = ({
       <Box sx={{ ml: 1, width: "10%" }}>
         <ColorAvatar
           sx={{ width: 27, height: 27 }}
-          src={message.sender.imageUrl}
-          id={message.sender.workspaceParticipantId}
+          src={message.sender?.imageUrl}
+          id={message.sender?.workspaceParticipantId}
         />
       </Box>
       <Box width="30%">
@@ -52,7 +52,7 @@ const MessageCard: React.FC<MessageCardProps> = ({
           whiteSpace="nowrap"
           textOverflow="ellipsis"
         >
-          {message.sender.name}
+          {message.sender ? message.sender.name : "탈퇴한 사용자"}
         </Typography>
       </Box>
       <Box width="50%">

--- a/src/components/message/ReadMessageSection.tsx
+++ b/src/components/message/ReadMessageSection.tsx
@@ -1,11 +1,11 @@
 import React from "react"
-import { Avatar, Box, Button, Divider, Typography } from "@mui/material"
+import { Box, Button, Divider, Typography } from "@mui/material"
 import { MessageSender, MessageSummary } from "_types/workspace"
-import { TEST_IMAGE_URL } from "env"
 import { deleteMessageApi } from "api/workspace"
 import { useAlert } from "hooks/useAlert"
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos"
 import ConfirmDialog from "components/common/ConfirmDialog"
+import ColorAvatar from "components/common/ColorAvatar"
 
 interface ReadMessageSectionProps {
   workspaceId: number | undefined
@@ -20,13 +20,17 @@ const ReadMessageSection = ({
   onBackButtonClick,
   onReplyClick,
 }: ReadMessageSectionProps) => {
-  const { addSuccess } = useAlert()
+  const { addSuccess, addError } = useAlert()
 
   const [deleteMessageModalOpen, setDeleteMessageModalOpen] =
     React.useState<boolean>(false)
 
   const handleReplyClick = () => {
     if (message) {
+      if (!message.sender) {
+        addError("탈퇴한 사용자에게 쪽지를 보낼 수 없습니다.")
+        return
+      }
       onReplyClick(message.sender)
     }
   }
@@ -55,8 +59,14 @@ const ReadMessageSection = ({
       </Box>
       <Divider sx={{ mb: 2 }} />
       <Box sx={{ m: 2, my: 2, display: "flex", alignItems: "center" }}>
-        <Avatar src={message?.sender.imageUrl || TEST_IMAGE_URL} />
-        <Typography>{message?.sender.name}</Typography>
+        <ColorAvatar
+          sx={{ width: 27, height: 27 }}
+          src={message?.sender?.imageUrl}
+          id={message?.sender?.workspaceParticipantId}
+        />
+        <Typography>
+          {message?.sender ? message.sender.name : "탈퇴한 사용자"}
+        </Typography>
       </Box>
       <Typography sx={{ m: 2, pl: 1, fontSize: 18, fontWeight: "bold" }}>
         {message?.title}


### PR DESCRIPTION
- MessageSender 타입 null 추가
- MessageSender의 타입이 null일 경우
  - 기본 이미지, 사용자 이름 (탈퇴한 사용자)로 표시
  - 탈퇴한 사용자에게는 답장하기 불가능